### PR TITLE
Add now.json config for deploying to ZEIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,10 @@ This app demonstrates how you can build a marketing site using Next.js on the Fr
 
 <img src="https://user-images.githubusercontent.com/6391763/54627869-47b56500-4a9a-11e9-812e-ddb71b56f56e.png" alt="Preview">
 
-<!-- prettier-ignore-start -->
-
-![Netlify Status][netlify-badge]
-
-<!-- prettier-ignore-end -->
 
 ## Demo
 
-Please check out the Netlify demo at https://buttercms-marketing-site-nextjs-react.netlify.com/.
+Please check out the ZEIT demo at https://testing-nextjs-apps.ghoshnirmalya.now.sh/.
 
 ## Development
 
@@ -55,12 +50,12 @@ If you prefer `npm`, you can do `npm run export` instead of `yarn export`.
 * [React](https://facebook.github.io/react/) - A JavaScript library for building user interfaces
 * [Screely](https://www.screely.com/) - Instantly turn your screenshot into a beautiful design mockup
 
+## Deploying
+
+1. Create a ZEIT account at https://zeit.co/signup and download [the CLI](https://zeit.co/download)
+2. Add the API key as a secret `now secrets add butter-cms-api-key "YOUR_API_KEY"`
+3. Run `now` at the project root
+
 ## License
 
 MIT Licensed. Copyright (c) ButterCMS 2019.
-
-<!-- prettier-ignore-start -->
-
-[netlify-badge]: https://api.netlify.com/api/v1/badges/6d6612a8-c4f4-44d6-a5d7-81e6afec737b/deploy-status
-
-<!-- prettier-ignore-end -->

--- a/now.json
+++ b/now.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [{
+    "src": "package.json",
+    "use": "@now/static-build",
+    "config": { "distDir": "out" }
+  }],
+  "build": {
+    "env": {
+      "BUTTER_CMS_API_KEY": "@butter-cms-api-key"
+    }
+  }
+}


### PR DESCRIPTION
This adds config for deploying to zeit.co.

Once you have an account at zeit.co, download the CLI and configure your API key as a secret.

now secrets add butter-cms-api-key "YOUR_API_KEY"

Finally, run now at the project root.